### PR TITLE
Cache expired posts

### DIFF
--- a/devvit.yaml
+++ b/devvit.yaml
@@ -1,2 +1,2 @@
 name: fundraisers-app
-version: 1.1.3.6
+version: 1.1.3.8

--- a/devvit.yaml
+++ b/devvit.yaml
@@ -1,2 +1,2 @@
 name: fundraisers-app
-version: 1.1.3.26
+version: 1.1.3.30

--- a/devvit.yaml
+++ b/devvit.yaml
@@ -1,2 +1,2 @@
 name: fundraisers-app
-version: 1.1.3.8
+version: 1.1.3.9

--- a/devvit.yaml
+++ b/devvit.yaml
@@ -1,2 +1,2 @@
 name: fundraisers-app
-version: 1.1.3.9
+version: 1.1.3.26

--- a/devvit.yaml
+++ b/devvit.yaml
@@ -1,2 +1,2 @@
 name: fundraisers-app
-version: 1.1.2.2
+version: 1.1.3.6

--- a/src/components/Fundraiser.tsx
+++ b/src/components/Fundraiser.tsx
@@ -427,7 +427,7 @@ export function FundraiserView(
                       isExpanded={isButtonExpanded}
                       onPress={() => {
                         if (fundraiserInfo) {
-                          console.log("Navigating to fundraiser URL:", fundraiserUrl);
+                          //console.log("Navigating to fundraiser URL:", fundraiserUrl);
                           context.ui.navigateTo(fundraiserUrl);
                         }
                       }}

--- a/src/components/Fundraiser.tsx
+++ b/src/components/Fundraiser.tsx
@@ -49,8 +49,8 @@ function generateDonateFundraiserURL(
     if (!baseUrl) return ''; // TODO: better default?
     const utm_content = fundraiserInfo?.id ? `&utm_content=${fundraiserInfo.id}` : '';
     const utm_campaign = subreddit ? `&utm_campaign=${subreddit}`: '';
-    const utm = `?utm_source=reddit&utm_medium=fundraisers${utm_content}${utm_campaign}`;
-    return `${baseUrl}#/donate${utm}`;
+    const utm = `?utm_source=reddit&utm_medium=fundraisers${utm_content}${utm_campaign}#/donate`;
+    return `${baseUrl}${utm}`;
 }
 
 

--- a/src/components/Fundraiser.tsx
+++ b/src/components/Fundraiser.tsx
@@ -404,17 +404,17 @@ export function FundraiserView(
                     </text>
                   </vstack>
                 </hstack>
-                <hstack width='33%' alignment='center middle' borderColor={DEBUG_MODE ? 'red' : 'neutral-border-weak'} border={DEBUG_MODE ? 'thin' : 'none'}>
+                <hstack width='34%' alignment='center middle' borderColor={DEBUG_MODE ? 'red' : 'neutral-border-weak'} border={DEBUG_MODE ? 'thin' : 'none'}>
                   {status === 'completed' || status === 'expired' ? (
                     <text 
                       size='small' 
                       weight='bold' 
-                      color='neutral-content-strong'
+                      color={everyGreen}
                       onPress={() => {
                         context.ui.navigateTo(baseFundraiserUrl);
                       }}
                     >
-                      This fundraiser has ended. Click here to view the results.
+                      Fundraiser ended!
                     </text>
                   ) : (
                     <FancyButton
@@ -435,7 +435,7 @@ export function FundraiserView(
                     </FancyButton>
                   )}
                 </hstack>
-                <hstack width='33%' alignment='end middle' borderColor={DEBUG_MODE ? 'red' : 'neutral-border-weak'} border={DEBUG_MODE ? 'thin' : 'none'}>
+                <hstack width='32%' alignment='end middle' borderColor={DEBUG_MODE ? 'red' : 'neutral-border-weak'} border={DEBUG_MODE ? 'thin' : 'none'}>
                   <spacer grow />
                 </hstack>
               </hstack>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import { convertToFormData } from './utils/formUtils.js';
 import { existingFundraiserForm } from './forms/ExistingFundraiserForm.js';
 import { updateCachedFundraiserDetails, sendFundraiserUpdates } from './utils/renderUtils.js';
 import { getFundraiserSummary, validateAndCreateJob } from './utils/jobUtils.js';
+import { isFundraiserFinished } from './utils/formUtils.js';
 
 Devvit.configure({
   redditAPI: true,
@@ -339,7 +340,7 @@ Devvit.addSchedulerJob({
       }
 
       const status = cachedForm.getStatus();
-      if (status === FundraiserStatus.Completed || status === FundraiserStatus.Expired) {
+      if (isFundraiserFinished(status)) {
         console.log(`Skipping completed/expired fundraiser: ${postId}`);
         continue;
       }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -358,7 +358,6 @@ Devvit.addSchedulerJob({
         console.error(`Error fetching fundraiser raised details for postId: ${postId}`, error);
         continue;
       }
-
       if (updatedDetails === 'NOT_FOUND' || isFundraiserExpired(fundraiserInfo)) {
         console.log(`Fundraiser completed or expired for postId: ${postId}. Marking as completed.`);
         try {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,13 @@ export interface TypeMapping {
     fundraiserDetails: EveryFundraiserRaisedDetails;
     fundraiserCreationResponse: FundraiserCreationResponse;
     everyExistingFundraiserInfo: EveryExistingFundraiserInfo;
+    fundraiserStatus: FundraiserStatus;
+}
+
+export enum FundraiserStatus {
+  Active = 'active',
+  Completed = 'completed',
+  Expired = 'expired'
 }
 
 export type BaseFormFields = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,8 +14,9 @@ export interface TypeMapping {
 
 export enum FundraiserStatus {
   Active = 'active',
-  Completed = 'completed',
-  Expired = 'expired'
+  Completed = 'completed', // completed comes from every.org via the existing fundraiser info active boolean
+  Expired = 'expired', // expired is determined from every.org via comparison with the end date field 
+  Unknown = 'unknown' // unknown is used as a fallback when the status is not yet known
 }
 
 export type BaseFormFields = {

--- a/src/utils/CachedForm.ts
+++ b/src/utils/CachedForm.ts
@@ -77,7 +77,7 @@ export class CachedForm {
         if (active !== null) {
             return active ? FundraiserStatus.Active : FundraiserStatus.Completed;
         }
-        return FundraiserStatus.Active; // Default to Active if status is not set
+        return FundraiserStatus.Unknown; // Default to Unknown if status is not set
     }
 
     serializeForRedis(): Record<string, any> {

--- a/src/utils/Redis.ts
+++ b/src/utils/Redis.ts
@@ -101,7 +101,6 @@ export async function getCachedForm(
  */
 export async function addOrUpdatePostInRedis(redis: RedisClient, postId: string, endDate: Date | null): Promise<void> {
     // Use a very distant future date if endDate is null
-    console.log("endDate: ", endDate);
     const score = endDate ? endDate.getTime() : new Date('2054-12-31').getTime();
     await redis.zAdd(RedisKey.AllSubscriptions, { score, member: postId });
     console.log(`Post ${postId} added or updated with end date score ${score}`);

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -51,3 +51,14 @@ export const getTomorrowDate = (): Date => {
     const today = new Date();
     return new Date(today.setDate(today.getDate() + 1));
 };
+
+export function isFundraiserExpired(fundraiserInfo: EveryExistingFundraiserInfo | SerializedEveryExistingFundraiserInfo): boolean {
+  if (!fundraiserInfo.endDate) {
+    return false; // If there's no end date, the fundraiser doesn't expire
+  }
+
+  const endDate = fundraiserInfo.endDate instanceof Date ? fundraiserInfo.endDate : new Date(fundraiserInfo.endDate);
+  const currentDate = new Date();
+
+  return currentDate > endDate;
+}

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -1,4 +1,4 @@
-import { EveryNonprofitInfo } from "../types/index.js";
+import { EveryNonprofitInfo, FundraiserStatus } from "../types/index.js";
 
 /**
  * Converts an array of EveryNonprofitInfo objects into a format suitable for forms in the Devvit API.
@@ -42,4 +42,8 @@ export function fundraiserUrlHelper(url: string): { nonprofitIdentifier: string;
       }
       throw error;
   }
+}
+
+export function isFundraiserFinished(status: FundraiserStatus): boolean {
+  return status === FundraiserStatus.Completed || status === FundraiserStatus.Expired;
 }

--- a/src/utils/jobUtils.ts
+++ b/src/utils/jobUtils.ts
@@ -4,7 +4,7 @@ import { fetchPostsToUpdate, getCachedForm } from './Redis.js';
 
 export async function getFundraiserSummary(context: Pick<Devvit.Context, 'redis' | 'reddit'>): Promise<string> {
   const { redis, reddit } = context;
-  const postsToUpdate = await fetchPostsToUpdate(redis);
+  const postsToUpdate = await fetchPostsToUpdate(redis); //FIXME: if a post is deleted or expired before the summary job runs, no summary for the last day will be sent
   let summary = '';
 
   // Get the subreddit name

--- a/src/utils/renderUtils.ts
+++ b/src/utils/renderUtils.ts
@@ -126,6 +126,12 @@ export async function updateCachedFundraiserDetails(context: Pick<Context, "redi
         return null;
     }
 
+    const currentStatus = cachedForm.getStatus();
+    if (currentStatus === 'expired') {
+        // If the fundraiser is already expired, don't update its details
+        return null;
+    }
+
     let hasChanges = false;
 
     if (updatedDetails.raised !== fundraiserRaisedDetails.raised) {


### PR DESCRIPTION
 Fix for expired or completed fundraisers
    
    * Implemented a fix for the case where a fundraiser expires or
      completes, thus causing the cachedForm to be deleted and risking the
      fundraiser being unable to render with any data
    * The fix stores a new 'status' value under the postId in the cachedForm
    * When the new check_fundraiser_status job runs (every minute) it checks every.org to see if the fundraiser has ended 
       and if it has, it updates the cachedForm status as well as the cachedForm existingfundraiserinfo.active property, and 
       deletes the postId from the list of posts to update, which is used by the update_fundraiser_posts job.
    * When the update_fundraiser_posts job runs, it fetches the latest
      details from every.org and if the status has become expired,
      it sets that in the cachedForm and removes the postId from the list of
      postsIds with subscriptions
    * Posts that aren't in the subscription list will still render from the
      data in the cached form, but wont receive updates via the realtime
      channel
    * If a post is completed or expired, the donate button disappears in
      favor of text saying the fundraiser is over and links to the fundraiser main page.
